### PR TITLE
fix: add missing object destructure for useEffect conditional firing

### DIFF
--- a/docs/bach-withHook.md
+++ b/docs/bach-withHook.md
@@ -38,7 +38,7 @@ export default compose(
     ({count}) => () => {
       console.log(`Count ${count}`);
     },
-    count => [count],
+    ({count}) => [count],
   ]),
 )(Component);
 ```


### PR DESCRIPTION
Absolutely awesome work on this library, I'm planning to advocate this in future projects.

I'm not 100% sure if my assumption is correct here, but I'm assuming in this case the array that drives the conditional firing in the `useEffect` hook would always result in the function being passed into the first argument of the `useEffect` hook to fire? A destructure is necessary to extract the `count` prop and use that to drive the conditional firing.

Cheers.